### PR TITLE
Add sync event, and option to exclude history

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,14 +14,16 @@ class Live extends Readable {
     this.onput = this.onput.bind(this)
     this.ondel = this.ondel.bind(this)
     this.onbatch = this.onbatch.bind(this)
-
     db.on('put', this.onput)
     db.on('del', this.ondel)
     db.on('batch', this.onbatch)
 
-    db
-      .createReadStream(opts)
-      .on('data', ({ key, value }) => this.onput(key, value))
+    if (opts.old !== false) {
+      db
+        .createReadStream(opts)
+        .on('data', ({ key, value }) => this.onput(key, value))
+        .on('end', () => this.emit('sync'))
+    }
   }
 
   start () {

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,13 @@ $ npm install level-live
 - `start`
 - `end`
 
+Additional options are:
+- `old` set to false to skip past entries and only listen live
+
+### Event `sync`
+
+Emitted once the live stream finished the past and caught up to the present.
+
 ## License
 
 MIT

--- a/test.js
+++ b/test.js
@@ -55,3 +55,48 @@ test('no opts', t => {
   })
   db.put('foo', 'bar')
 })
+
+test('ready event', t => {
+  t.plan(5)
+  const db = level('ready')
+  db.put('a', 'a')
+  db.put('b', 'b')
+  setTimeout(() => {
+    let i = 0
+    const stream = new Live(db)
+    stream.on('data', op => {
+      i++
+      if (i === 1) t.equal(op.key, 'a')
+      if (i === 2) t.equal(op.key, 'b')
+      if (i === 3) t.equal(op.key, 'c')
+      if (i === 4) t.equal(op.key, 'd')
+    })
+    stream.on('sync', () => {
+      t.equal(i, 2)
+    })
+    setTimeout(() => {
+      db.put('c', 'c')
+      db.put('d', 'd')
+    }, 100)
+  }, 10)
+})
+
+test('skip old', t => {
+  t.plan(2)
+  const db = level('skip old')
+  db.put('a', 'a')
+  db.put('b', 'b')
+  let i = 0
+  setTimeout(() => {
+    const stream = new Live(db, { old: false })
+    stream.on('data', op => {
+      i++
+      if (i === 1) t.equal(op.key, 'c')
+      if (i === 2) t.equal(op.key, 'd')
+    })
+  }, 50)
+  setTimeout(() => {
+    db.put('c', 'c')
+    db.put('d', 'd')
+  }, 100)
+})


### PR DESCRIPTION
This adds two little features I needed:

* emit a `sync` event once reading the history is done and the stream transitions to live mode
* optionally support a `[ old: false }` op to disable the read stream and only listen for new ops