### PR TITLE
Support key encodings

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,14 +14,16 @@ class Live extends Readable {
     this.onput = this.onput.bind(this)
     this.ondel = this.ondel.bind(this)
     this.onbatch = this.onbatch.bind(this)
-
     db.on('put', this.onput)
     db.on('del', this.ondel)
     db.on('batch', this.onbatch)
 
-    db
-      .createReadStream(opts)
-      .on('data', ({ key, value }) => this.onput(key, value))
+    if (opts.old !== false) {
+      db
+        .createReadStream(opts)
+        .on('data', ({ key, value }) => this.onput(key, value))
+        .on('end', () => this.emit('sync'))
+    }
   }
 
   start () {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const { Readable } = require('stream')
 const ltgt = require('ltgt')
+const Codec = require('level-codec')
 
 class Live extends Readable {
   constructor (db, opts = {}) {
@@ -17,6 +18,9 @@ class Live extends Readable {
     db.on('put', this.onput)
     db.on('del', this.ondel)
     db.on('batch', this.onbatch)
+
+    this.codec = Codec(opts)
+    this.ltgt = this.codec.encodeLtgt(opts)
 
     if (opts.old !== false) {
       db
@@ -39,7 +43,8 @@ class Live extends Readable {
   }
 
   op (op) {
-    if (ltgt.contains(this.opts, op.key)) {
+    const key = this.codec.encodeKey(op.key)
+    if (ltgt.contains(this.ltgt, key)) {
       this.buf.push(op)
       if (this.buf.length === 1) this.start()
     }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "tap": "^11.0.0"
   },
   "dependencies": {
+    "level-codec": "^9.0.1",
     "ltgt": "^2.2.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,13 @@ $ npm install level-live
 - `start`
 - `end`
 
+Additional options are:
+- `old` set to false to skip past entries and only listen live
+
+### Event `sync`
+
+Emitted once the live stream finished the past and caught up to the present.
+
 ## License
 
 MIT

--- a/test.js
+++ b/test.js
@@ -55,3 +55,48 @@ test('no opts', t => {
   })
   db.put('foo', 'bar')
 })
+
+test('ready event', t => {
+  t.plan(5)
+  const db = level('ready')
+  db.put('a', 'a')
+  db.put('b', 'b')
+  setTimeout(() => {
+    let i = 0
+    const stream = new Live(db)
+    stream.on('data', op => {
+      i++
+      if (i === 1) t.equal(op.key, 'a')
+      if (i === 2) t.equal(op.key, 'b')
+      if (i === 3) t.equal(op.key, 'c')
+      if (i === 4) t.equal(op.key, 'd')
+    })
+    stream.on('sync', () => {
+      t.equal(i, 2)
+    })
+    setTimeout(() => {
+      db.put('c', 'c')
+      db.put('d', 'd')
+    }, 100)
+  }, 10)
+})
+
+test('skip old', t => {
+  t.plan(2)
+  const db = level('skip old')
+  db.put('a', 'a')
+  db.put('b', 'b')
+  let i = 0
+  setTimeout(() => {
+    const stream = new Live(db, { old: false })
+    stream.on('data', op => {
+      i++
+      if (i === 1) t.equal(op.key, 'c')
+      if (i === 2) t.equal(op.key, 'd')
+    })
+  }, 50)
+  setTimeout(() => {
+    db.put('c', 'c')
+    db.put('d', 'd')
+  }, 100)
+})


### PR DESCRIPTION
Currently, when using different key encodings, the key encodings are not applied to messages emitted when in live mode (after the original read stream finishes).

This PR makes the key uniform in read and live mode by using the level-codec module (which levelup etc also use).